### PR TITLE
Add TLS support to the listener

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,8 +33,12 @@ default[:vault][:conf][:listener][:cluster_addr]  = '0.0.0.0' # Must be overridd
 default[:vault][:conf][:listener][:cluster_port]  = '8201'
 default[:vault][:conf][:listener][:tls_disable]   = false
 
+default[:vault][:conf][:listener][:cert_dir] = "/etc/vault/cert"
+default[:vault][:conf][:listener][:cert]     = "/etc/vault/cert/vault.crt" # NOTE: The cookbook will not place these files
+default[:vault][:conf][:listener][:key]      = "/etc/vault/cert/vault.key"
+
 # NOTE: These should be physical interface addresses, not 0.0.0.0 or loopback
-default[:vault][:conf][:api_addr]     = "http://#{node[:fqdn]}" 
+default[:vault][:conf][:api_addr]     = "http://#{node[:fqdn]}"
 default[:vault][:conf][:cluster_addr] = "http://#{node[:fqdn]}"
 
 default[:vault][:conf][:storage][:socket] = "127.0.0.1:8500"  # ip and port that consul is listening on

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email 'you@example.com'
 license 'All Rights Reserved'
 description 'Installs/Configures vault'
 long_description 'Installs/Configures vault'
-version '0.1.0'
+version '0.1.1'
 chef_version '>= 12.14' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,5 +4,6 @@ end
 
 include_recipe "vault::user"
 include_recipe "vault::config"
+include_recipe "vault::tls"
 include_recipe "vault::vault"
 include_recipe "vault::systemd"

--- a/recipes/tls.rb
+++ b/recipes/tls.rb
@@ -1,0 +1,29 @@
+directory node[:vault][:conf][:listener][:cert_dir] do
+  recursive true
+  action :create
+  owner node[:vault][:user]
+  group node[:vault][:group]
+  mode "0700"
+end
+
+
+# Enforce file permissions but do not change the file
+# Chef will create an empty file if not exists, which will
+# cause fault to fail if tsl is enabled.
+#
+# NOTE: set `node[:vault][:conf][:listener][:tls_disable] = true`
+# to verify that the service is working. Then manually add the cert
+# and key to the cert directory.
+#
+[node[:vault][:conf][:listener][:cert], node[:vault][:conf][:listener][:key]].each do |cert_file|
+  file cert_file do
+    owner node[:vault][:user]
+    group node[:vault][:group]
+
+    # vault should read but never write
+    mode '0400'
+
+    # enforce permissions but never overwrite the cert
+    action :create
+  end
+end

--- a/templates/server.hcl.erb
+++ b/templates/server.hcl.erb
@@ -4,7 +4,12 @@ ui = "<%=node[:vault][:conf][:ui]%>"
 listener "tcp" {
   address          = "<%=node[:vault][:conf][:listener][:bind_addr]%>:<%=node[:vault][:conf][:listener][:bind_port]%>"
   cluster_address  = "<%=node[:vault][:conf][:listener][:cluster_addr]%>:<%=node[:vault][:conf][:listener][:cluster_port]%>"
-  tls_disable      = "<%=node[:vault][:conf][:listener][:tls_disable]%>"
+
+  // TLS options
+  tls_disable     = "<%=node[:vault][:conf][:listener][:tls_disable]%>"
+  tls_cert_file   = "<%=node[:vault][:conf][:listener][:cert]%>"
+  tls_key_file    = "<%=node[:vault][:conf][:listener][:key]%>"
+  tls_min_version = "tls12"
 }
 
 

--- a/test/integration/config_test.rb
+++ b/test/integration/config_test.rb
@@ -50,6 +50,33 @@ describe command('sudo cat /etc/vault/vault.d/server.hcl | grep tls_disable | xa
         }
 end
 
+describe command('sudo cat /etc/vault/vault.d/server.hcl | grep tls_cert_file | xargs') do
+    # NOTE: `xargs` removes the quotes from the value!
+    its('stdout') {
+        should match (
+            "tls_cert_file = #{node['vault']['conf']['listener']['tls_cert_file']}"
+            )
+        }
+end
+
+describe command('sudo cat /etc/vault/vault.d/server.hcl | grep tls_key_file | xargs') do
+    # NOTE: `xargs` removes the quotes from the value!
+    its('stdout') {
+        should match (
+            "tls_key_file = #{node['vault']['conf']['listener']['tls_key_file']}"
+            )
+        }
+end
+
+describe command('sudo cat /etc/vault/vault.d/server.hcl | grep tls_min_version | xargs') do
+    # NOTE: `xargs` removes the quotes from the value!
+    its('stdout') {
+        should match (
+            "tls_min_version = #{node['vault']['conf']['listener']['tls_min_version']}"
+            )
+        }
+end
+
 describe command('sudo cat /etc/vault/vault.d/server.hcl | grep address | xargs') do
     # NOTE: `xargs` removes the quotes from the value!
     its('stdout') {
@@ -68,14 +95,6 @@ describe command('sudo cat /etc/vault/vault.d/server.hcl | grep cluster_address 
         }
 end
 
-describe command('sudo cat /etc/vault/vault.d/server.hcl | grep tls_disable | xargs') do
-    # NOTE: `xargs` removes the quotes from the value!
-    its('stdout') {
-        should match (
-            "tls_disable = #{node['vault']['conf']['listener']['tls_disable']}"
-            )
-        }
-end
 
 describe command('sudo cat /etc/vault/vault.d/server.hcl | grep api_addr | xargs') do
     # NOTE: `xargs` removes the quotes from the value!

--- a/test/integration/tls.rb
+++ b/test/integration/tls.rb
@@ -1,0 +1,17 @@
+describe file('/etc/vault/cert') do
+    its('mode') { should cmp '0700' }
+    its('owner') { should eq 'vault' }
+    its('group') { should eq 'vault' }
+end
+
+describe file('/etc/vault/cert/vault.crt') do
+    its('mode') { should cmp '0400' }
+    its('owner') { should eq 'vault' }
+    its('group') { should eq 'vault' }
+end
+
+describe file('/etc/vault/cert/vault.key') do
+    its('mode') { should cmp '0400' }
+    its('owner') { should eq 'vault' }
+    its('group') { should eq 'vault' }
+end


### PR DESCRIPTION
Chef will add emtpy certificate files with the permissions `0400`. These files can be manually updated with real certificates,  and chef will never modify their contents. Chef will, however, preserve the permissions `0400`. 

If `tls_disable` is true, vault will not attempt to read the initial certificates (that are just empty files), this allows local development without tls, but an easy way to enable it in production. 